### PR TITLE
Being able to add multiple definitions

### DIFF
--- a/script.ts
+++ b/script.ts
@@ -341,7 +341,7 @@ function renderLists(): void{
 
 function renderQuestion(wordObject: Word): void{
     const isReversed = practising.list!.isReversed;
-    const allTranslations = wordObject.answers.join(" / ");
+    const allTranslations = wordObject.answers.map(a => a.ans).join(" / ");
 
     if (isReversed) {
         word.innerHTML = allTranslations;


### PR DESCRIPTION
1. can add multiple definitions for a word, stored as an array of Answer[] objects.
2. in normal mode, entering any of the translations as the answer is considered correct
3. in reverse mode, the question displays all the translations. 

<img width="570" height="380" alt="image" src="https://github.com/user-attachments/assets/4ed1f5ee-0b3f-4adf-b00e-60e7626b0012" />

normal mode:

<img width="794" height="371" alt="image" src="https://github.com/user-attachments/assets/b3869170-9c88-47b1-8c27-1359c8c20fd0" />

reverse mode: 

<img width="807" height="384" alt="image" src="https://github.com/user-attachments/assets/bca545e7-b949-4398-9cc7-7858a7dfa875" />

Local storage:

<img width="395" height="243" alt="image" src="https://github.com/user-attachments/assets/6c871175-1c2b-485e-b3f2-01865403c60c" />

